### PR TITLE
fix: Add missing function parentheses

### DIFF
--- a/solutions/history-func/ProcessProductViews.cs
+++ b/solutions/history-func/ProcessProductViews.cs
@@ -25,7 +25,8 @@ namespace History.Api
 
         [Function(nameof(ProcessProductViews))]
         public async Task StreamTrigger(
-            [RedisStreamTrigger("AZURE_REDIS_CONNECTION_STRING", "%PRODUCT_VIEWS_STREAM_NAME%")] string entry)
+            [RedisStreamTrigger("AZURE_REDIS_CONNECTION_STRING", "%PRODUCT_VIEWS_STREAM_NAME%")] string entry
+        )
         {
             _logger.LogInformation("Processing a new stream entry: {entry}", entry);
 

--- a/src/history-func/ProcessProductViews.cs
+++ b/src/history-func/ProcessProductViews.cs
@@ -26,6 +26,7 @@ namespace History.Api
         [Function(nameof(ProcessProductViews))]
         public async Task StreamTrigger(
             // TODO: Add the logic of the function trigger
+        )
         {
             _logger.LogInformation("Processing a new stream entry: {entry}", entry);
 


### PR DESCRIPTION
Add a missing closing parentheses to the signature of the Azure Function main method.

noissue