### PR TITLE
fix: Deploy Function Apps as .NET7 isolated

### DIFF
--- a/terraform/func-cache.tf
+++ b/terraform/func-cache.tf
@@ -14,7 +14,7 @@ resource "azurerm_linux_function_app" "func_cache" {
   }
 
   app_settings = {
-    FUNCTIONS_WORKER_RUNTIME              = "dotnet"
+    FUNCTIONS_WORKER_RUNTIME              = "dotnet-isolated"
     AZURE_REDIS_CONNECTION_STRING         = azurerm_redis_cache.this.primary_connection_string
     REDIS_PRODUCT_ALL                     = "products:all"
     CATALOG_API_URL                       = azurerm_api_management.this.gateway_url
@@ -25,6 +25,7 @@ resource "azurerm_linux_function_app" "func_cache" {
   site_config {
     application_stack {
       dotnet_version = "7.0"
+      use_dotnet_isolated_runtime = true
     }
   }
 }

--- a/terraform/func-history.tf
+++ b/terraform/func-history.tf
@@ -14,10 +14,9 @@ resource "azurerm_linux_function_app" "func_history" {
   }
 
   app_settings = {
-    FUNCTIONS_WORKER_RUNTIME              = "dotnet"
+    FUNCTIONS_WORKER_RUNTIME              = "dotnet-isolated"
     AZURE_REDIS_CONNECTION_STRING         = azurerm_redis_cache.this.primary_connection_string
-    REDIS_PRODUCT_ALL                     = "products:all"
-    CATALOG_API_URL                       = azurerm_api_management.this.gateway_url
+    PRODUCT_VIEWS_STREAM_NAME             = "productViews"
     APPINSIGHTS_INSTRUMENTATIONKEY        = azurerm_application_insights.this.instrumentation_key
     APPLICATIONINSIGHTS_CONNECTION_STRING = azurerm_application_insights.this.connection_string
   }
@@ -25,6 +24,7 @@ resource "azurerm_linux_function_app" "func_history" {
   site_config {
     application_stack {
       dotnet_version = "7.0"
+      use_dotnet_isolated_runtime = true
     }
   }
 }


### PR DESCRIPTION
Force the deployment of the .NET7 functions to be done in isolated mode using the [use_dotnet_isolated_runtime](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_function_app#use_dotnet_isolated_runtime
) flag (even though that is the only way of deploying functions with .NET7).

noissue