### PR TITLE
fix: Fix API Latency control issue

### DIFF
--- a/src/catalog-api/SimulatedDatabaseLatency.cs
+++ b/src/catalog-api/SimulatedDatabaseLatency.cs
@@ -12,8 +12,8 @@ public class SimulatedDatabaseLatency : ISimulatedDatabaseLatency
 
     public SimulatedDatabaseLatency(IConfiguration configuration)
     {
-        _simulatedDBLatencyInSeconds = SimulatedLatencyInSeconds();
         _configuration = configuration;
+        _simulatedDBLatencyInSeconds = SimulatedLatencyInSeconds();
     }
 
     private int SimulatedLatencyInSeconds()


### PR DESCRIPTION
Fix the control of latency in the catalog-api by setting the value of `_configuration` before using it to get the value of latency to inject.

noissue