### PR TITLE
Update workshop.md to have dotnet dev-certs https

### DIFF
--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -404,6 +404,13 @@ You can now run debug for the catalog-api by selecting **Run and Debug** in the 
 
 ![Debug-Catalog-Api](./assets/vscode-debug-api.png)
 
+**If you get an exeception about HTTPS, please run the command in the terminal**
+
+```bash 
+cd src/catalog-api
+dotnet dev-certs https
+``` 
+
 Depending on the environment you are using : 
 - Devcontainer : 
     - Once the API is running, browse for the url: http://localhost:5076/products and you should see the list of products.


### PR DESCRIPTION
you can have a issue in your local dev environment regarding the https and you need to run dotnet dev-certs https