### PR TITLE
Needs to pass --csharp in func publish

### DIFF
--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -955,7 +955,7 @@ To debug the Cache Refresh Azure Function in VS Code, you will need to start Azu
 Deploy your function using the VS Code extension or by command line:
 
 ```bash
-func azure functionapp publish <NAME_OF_YOUR_FUNCTION_APP>
+func azure functionapp publish <NAME_OF_YOUR_FUNCTION_APP> --csharp
 ```
 
 #### Test the Azure Function


### PR DESCRIPTION
![image](https://github.com/microsoft/hands-on-lab-redis/assets/13451867/5a631fd0-8d15-4670-a8af-6b04b7725ac4)
Need to do pass --csharp like that func azure functionapp publish func-cache-dev-we-rds-e2f5 --csharp 